### PR TITLE
chore(deps): version bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- v0.1.1 - Version bumps for TypeScript dependencies and openapi-generator
 - v0.1.0 - Allow specification of registry namespace and repository URL
 - v0.0.12 - Expose swagger models in client package by copying `*.public-models.ts` files
 - v0.0.7 - Fix missing cd in v0.0.6

--- a/generate-client.sh
+++ b/generate-client.sh
@@ -14,7 +14,7 @@ echo "Hatch action started."
 echo "Downloading and installing prerequisites..."
 apt-get update
 apt-get -y install wget jq
-wget --quiet https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar -O openapi-generator-cli.jar
+wget --quiet https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.0/openapi-generator-cli-5.1.0.jar -O openapi-generator-cli.jar
 if [ $? -ne 0 ]
 then
   echo "ERROR: cannot download openapi generator binary; aborting."

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -16,15 +16,15 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@nestjs/swagger": "^4.4.0",
-    "class-validator": "^0.12.2",
-    "axios": "^0.19.1",
-    "url": "^0.11.0",
-    "typescript": "^3.7.4"
+    "@nestjs/swagger": "^4.8.0",
+    "class-validator": "^0.13.1",
+    "axios": "^0.21.1",
+    "url": "^0.13.1",
+    "typescript": "^4.2.4"
   },
   "peerDependencies": {
     "@nestjs/swagger": "^4.4.0",
-    "class-validator": "^0.12.2",
-    "axios": "^0.19.1"
+    "class-validator": "^0.13.1",
+    "axios": "^0.21.1"
   }
 }


### PR DESCRIPTION
Bumps dependencies of the generated client, as well as the openapi-generator version used.